### PR TITLE
Move Webhook config to Helm

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Each deployment scenario has its own README file with instructions on how to set
 ## Usage
 
 [Helm](https://helm.sh) must be installed to use these charts.
-Please refer to the [official documentation](https://helm.sh/docs/intro/install/) to get started.
+Please refer to the [official documentation](https://helm.sh/docs/intro/install/) to get started.  The below command assume a v3 Helm version, although the charts should work with Helm v2 the command options may be different. 
 
 ```shell
 helm repo add msm https://charts.mediastreamingmesh.io
@@ -41,9 +41,7 @@ helm search repo msm
 You can install charts using the following command:
 
 ```shell
-helm install --generate-name msm/CHART
-# OR
-helm install --name my-release msm/CHART
+helm install <your-name> msm/CHART --namespace <your-namespace> --create-namespace
 ```
 
 > **Tip**: List all installed releases using `helm list`.
@@ -51,7 +49,7 @@ helm install --name my-release msm/CHART
 To uninstall a chart release:
 
 ```shell
-helm delete my-release
+helm delete my-release --namespace <your-namespace>
 ```
 
 ## **Contributing**

--- a/deployments/msm/Chart.yaml
+++ b/deployments/msm/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.2
+version: 0.0.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/deployments/msm/templates/clusterrole.yaml
+++ b/deployments/msm/templates/clusterrole.yaml
@@ -28,6 +28,8 @@ rules:
       - nodes
     verbs:
       - get
+      - list
+      - watch
 ---
 # controller-prep
 apiVersion: rbac.authorization.k8s.io/v1

--- a/deployments/msm/templates/clusterrolebinding.yaml
+++ b/deployments/msm/templates/clusterrolebinding.yaml
@@ -8,7 +8,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: msm-admission-webhook-sa
-    namespace: {{ if eq .Values.kubernetesDistro "K8S" }}default{{ else }}gbear{{ end }}
+    namespace: {{ if eq .Values.kubernetesDistro "K8S" }}{{ .Release.Namespace }}{{ else }}gbear{{ end }}
 roleRef:
   kind: ClusterRole
   name: msm-admission-webhook-role
@@ -30,7 +30,7 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: msm-cni
-    namespace: {{ if eq .Values.kubernetesDistro "K8S" }}default{{ else }}gbear{{ end }}
+    namespace: {{ if eq .Values.kubernetesDistro "K8S" }}{{ .Release.Namespace }}{{ else }}gbear{{ end }}
 
 ---
 #msm-controller
@@ -46,8 +46,8 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 subjects:
   - kind: ServiceAccount
-    name: msm-controller
-    namespace: {{ if eq .Values.kubernetesDistro "K8S" }}default{{ else }}gbear{{ end }}
+    name: msm-controller-sa
+    namespace: {{ if eq .Values.kubernetesDistro "K8S" }}{{ .Release.Namespace }}{{ else }}gbear{{ end }}
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -63,5 +63,5 @@ roleRef:
   name: node-watcher
 subjects:
   - kind: ServiceAccount
-    name: msm-controller
-    namespace: {{ if eq .Values.kubernetesDistro "K8S" }}default{{ else }}gbear{{ end }}
+    name: msm-controller-sa
+    namespace: {{ if eq .Values.kubernetesDistro "K8S" }}{{ .Release.Namespace }}{{ else }}gbear{{ end }}

--- a/deployments/msm/templates/configmap.yaml
+++ b/deployments/msm/templates/configmap.yaml
@@ -3,6 +3,7 @@ kind: ConfigMap
 apiVersion: v1
 metadata:
   name: msm-cni-config
+  namespace: {{ if eq .Values.kubernetesDistro "K8S" }}{{ .Release.Namespace }}{{ else }}gbear{{ end }}
   labels:
     app: msm-cni
     {{- include "MSM.labels" . | nindent 4 }}

--- a/deployments/msm/templates/daemonset.yaml
+++ b/deployments/msm/templates/daemonset.yaml
@@ -3,6 +3,7 @@ kind: DaemonSet
 apiVersion: apps/v1
 metadata:
   name: msm-cni
+  namespace: {{ if eq .Values.kubernetesDistro "K8S" }}{{ .Release.Namespace }}{{ else }}gbear{{ end }}
   labels:
     app: msm-cni
     {{- include "MSM.labels" . | nindent 4 }}
@@ -77,6 +78,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: msm-gateway
+  namespace: {{ if eq .Values.kubernetesDistro "K8S" }}{{ .Release.Namespace }}{{ else }}gbear{{ end }}
   labels:
     msm: gateway
     {{- include "MSM.labels" . | nindent 4 }}

--- a/deployments/msm/templates/deployment.yaml
+++ b/deployments/msm/templates/deployment.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: msm-admission-webhook
+  namespace: {{ if eq .Values.kubernetesDistro "K8S" }}{{ .Release.Namespace }}{{ else }}gbear{{ end }}
   labels:
     app: msm-admission-webhook
     {{- include "MSM.labels" . | nindent 4 }}
@@ -62,6 +63,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.serviceAccountName
+            - name: IGNORED_NAMESPACE
+              value: {{ .Release.Namespace }}
+            - name: WEBHOOK_CONFIG_NAME
+              value: msm-admission-webhook-{{ .Release.Namespace }}
       nodeSelector:
         node-role.kubernetes.io/control-plane: {{ if eq .Values.kubernetesDistro "K8S" }}""{{ else }}"true"{{ end }}
 
@@ -71,6 +76,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: msm-controller
+  namespace: {{ if eq .Values.kubernetesDistro "K8S" }}{{ .Release.Namespace }}{{ else }}gbear{{ end }}
   labels:
     msm: controller
     {{- include "MSM.labels" . | nindent 4 }}
@@ -91,7 +97,7 @@ spec:
         - key: node-role.kubernetes.io/control-plane
           operator: Exists
           effect: NoSchedule
-      serviceAccountName: msm-controller
+      serviceAccountName: msm-controller-sa
       containers:
         - name: msm-controller
           image: "{{ .Values.controllerImage.name }}:{{ .Values.controllerImage.tag }}"

--- a/deployments/msm/templates/service.yaml
+++ b/deployments/msm/templates/service.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: msm-admission-webhook-svc
+  namespace: {{ if eq .Values.kubernetesDistro "K8S" }}{{ .Release.Namespace }}{{ else }}gbear{{ end }}
   labels:
     app: msm-admission-webhook
     {{- include "MSM.labels" . | nindent 4 }}
@@ -20,6 +21,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: msm-controller
+  namespace: {{ if eq .Values.kubernetesDistro "K8S" }}{{ .Release.Namespace }}{{ else }}gbear{{ end }}
   labels:
     msm: controller
     {{- include "MSM.labels" . | nindent 4 }}

--- a/deployments/msm/templates/serviceaccount.yaml
+++ b/deployments/msm/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: msm-cni
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "MSM.labels" . | nindent 4 }}
     app: msm-cni
@@ -12,6 +13,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: msm-admission-webhook-sa
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "MSM.labels" . | nindent 4 }}
 
@@ -20,7 +22,7 @@ metadata:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: msm-controller
+  name: msm-controller-sa
   labels:
     app: msm-controller
     {{- include "MSM.labels" . | nindent 4 }}

--- a/deployments/msm/templates/webhook.yaml
+++ b/deployments/msm/templates/webhook.yaml
@@ -1,0 +1,32 @@
+kind: MutatingWebhookConfiguration
+apiVersion: admissionregistration.k8s.io/v1
+metadata:
+  name: msm-admission-webhook-{{ .Release.Namespace }}
+  labels:
+webhooks:
+- admissionReviewVersions:
+    - v1
+  name:  msm-admission-webhook-{{ .Release.Namespace }}.mediastreamingmesh.io
+  clientConfig:
+    service:
+      name: msm-admission-webhook-svc
+      namespace: {{ .Release.Namespace }}
+      path: "/mutate"
+      port: 443
+  sideEffects: None
+  objectSelector:
+    matchExpressions:
+    - key: sidecar.mediastreamingmesh.io/inject
+      operator: In
+      values:
+      - "true"
+  rules:
+  - operations: [ "CREATE", "UPDATE" ]
+    apiGroups: [""]
+    apiVersions: ["v1"]
+    resources: ["pods"]
+    scope: "*"
+  failurePolicy: Ignore
+  sideEffects: None
+  timeoutSeconds: 10
+

--- a/deployments/msm/values.yaml
+++ b/deployments/msm/values.yaml
@@ -3,28 +3,7 @@ kubernetesDistro: "K8S"
 
 nodeSelector: "{{ if eq .Values.kubernetesDistro \"K8S\" }}{{ else if eq .Values.kubernetesDistro \"K3S\" }}true{{ end }}"
 
-# change the gbear to desired namespace for K3S.
-namespace: "{{ if eq .Values.kubernetesDistro \"K8S\" }}default{{ else if eq .Values.kubernetesDistro \"K3S\" }}gbear{{ end }}"
-
-cniClusterRole: msm-cni
-
-cniConfigMap: msm-cni-config
-
-webhookClusterRole: msm-admission-webhook-role
-
-webhookClusterRoleBinding: msm-admission-webhook-binding
-
-webhookServiceAccount: msm-admission-webhook-sa
-
-gatewayDaemonSet: msm-gateway
-
-gatewayName: gateway
-
-webhookDeployment: msm-admission-webhook
-
 controllerName: msm-controller
-
-controllerDeployment: controller
 
 cniImage:
   name: ghcr.io/media-streaming-mesh/msm-cni


### PR DESCRIPTION
This change uses Helm to create a
mutatingwebhookconfiguration that
determines which pods should go to the
the msm admission webhook for mutation.

It needs to be coordinated with a change
to the msm admission webhook.

It also make a few other chart changes,
primarily to allow the msm components to
be installed a specific namespace.

Additional info: 

USE of LABELS vs. ANNOTATIONS

The Kubernetes mutatingwebhookconfiguration delimits based on labels not annotations.   Therefore, this PR changes 
from an annotation to a label of the form:
```
sidecar.mediastreamingmesh.io/inject: true
```
Things might go badly if this change is used with the old webhook image.   I haven't
really tested that combination. 

I think we should generally not install msm in the default namespace.   With these changes I think
most things should work in a dedicated namespace but I did not do a full E2E test to make sure. 
The approach uses Helm to specify the namespace for the installation  

By default, this change will never try to mutate pods that are deployed in the same namespace as the msm components. 
This includes the default namespace if msm is installed there.   If this is problematic the PR can be updated to allow this. 

 
