### PR TITLE
Adds Readiness and liveness probes

### DIFF
--- a/deployments/msm/Chart.yaml
+++ b/deployments/msm/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.8
+version: 0.1.9
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/deployments/msm/templates/daemonset.yaml
+++ b/deployments/msm/templates/daemonset.yaml
@@ -110,6 +110,14 @@ spec:
           env:
             - name: LOG_LVL
               value: "DEBUG"
+          readinessProbe:
+            exec:
+              command: ["grpc-health-probe", "-addr=:9000"]
+            initialDelaySeconds: 2
+          livenessProbe:
+            exec:
+              command: ["grpc-health-probe", "-addr=:9000"]
+            initialDelaySeconds: 10
         - name: msm-rtsp-stub
           image: "{{ .Values.stubImage.name }}:{{ .Values.stubImage.tag }}"
           imagePullPolicy: IfNotPresent

--- a/deployments/msm/templates/deployment.yaml
+++ b/deployments/msm/templates/deployment.yaml
@@ -28,6 +28,16 @@ spec:
         - name: msm-admission-webhook
           image: "{{ .Values.webhookImage.name }}:{{ .Values.webhookImage.tag }}"
           imagePullPolicy: IfNotPresent
+          ports:
+          - protocol: TCP
+            containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /livenessz
+              port: 8080
+            initialDelaySeconds: 1
+            periodSeconds: 3
+            timeoutSeconds: 5
           env:
             - name: REPO
               value: "ciscolabs"


### PR DESCRIPTION
Adds a Liveness probe to the admission
web-hook and both readiness and liveness
probe to the rtp proxy

This changes the manifests to enable the readiness and liveness probes.  It should ONLY be merged after the liveness and
readiness changes in the admission-webhook and rtp-proxy have merged and associated images propagated. 

https://github.com/media-streaming-mesh/msm-admission-webhook/pull/16

https://github.com/media-streaming-mesh/msm-dp/pull/27

